### PR TITLE
Fix Issue #7: Correct jQuery reference link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
     <!-- Importing the Lato Google Font to the project. -->
     <link rel="stylesheet" href=style.css>
     <script src="../node_modules/jquery/dist/jquery.min.js"></script>
+    <script src="../node_modules/autosize/dist/autosize.min.js"></script>
 </head>
 <body>
 

--- a/src/index.html
+++ b/src/index.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"> 
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <!-- Allows web authors to choose what version of the Microsoft Internet Explorer is the best for the app.
     https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do-->
     <title>Welcome to CHARTA</title>
     <link href='http://fonts.googleapis.com/css?family=Lato&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
     <!-- Importing the Lato Google Font to the project. -->
     <link rel="stylesheet" href=style.css>
-    <script src="node_modules/jquery/dist/jquery.min.js"></script>
+    <script src="../node_modules/jquery/dist/jquery.min.js"></script>
 </head>
-<body> 
+<body>
 
 <div class="center-both-axis">
     <h3 class="header"> Chart(a) your life</h3>

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,14 @@
 
 
 $(document).ready(function() {
-    $('#editor').autosize(); //autosizes the textarea
+    autosize($('#editor')); //autosizes the textarea
     $('#delete').on('click', function(){
         $('#editor').slideToggle(); //removes the note from the view after clicking Delete btn
     });
     $('#new').on('click', function(){
         $('#editor').slideDown(); //displays the note after clicking new btn
     });
- }) 
-
+ })
 
 //Returns the first element that matches a specified CSS selector(s) in the document
 const notes = document.querySelector('#notes');
@@ -78,4 +77,4 @@ function checkEmpty() {
         notes.appendChild(untitled);
     }
 }
-// Credit (MIT License): https://github.com/healeycodes/tiny-note-taker 
+// Credit (MIT License): https://github.com/healeycodes/tiny-note-taker


### PR DESCRIPTION
From the commit text:

```
This commit should fix the problem in Issue #7 where enabling the
jQuery section causes JS to crash.  The reason why this wasn't
working was because jQuery actually wasn't being added in
index.html, because the local link was incorrect. (The only file
modified is index.html, because index.js is actually fine.)
```